### PR TITLE
Add striver sheet tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Stop getting stuck on bugs for hours. CI-MAN-YD analyzes your code instantly and
 - **Smart Hint System** - Syntax errors, logic issues, optimizations
 - **Clean Interface** - No clutter, just your code and helpful suggestions
 - **Submission History** - Track your progress and past analyses
+- **Striver Sheet Tracker** - Practice SDE questions in random order and mark
+  completed ones
 
 ## 🛠️ Tech Stack
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Code, Brain, User, History, Send, Lightbulb, AlertCircle, CheckCircle } from 'lucide-react';
+import StriverSheet from './StriverSheet';
 
 
 // API Service - normally you'd import this from services/api.js
@@ -29,6 +30,15 @@ const apiService = {
     } catch (error) {
       return { error: 'Backend not reachable' };
     }
+  },
+
+  async getStriverQuestions(shuffle = false) {
+    const query = shuffle ? '?shuffle=true' : '';
+    const response = await fetch(`${API_BASE_URL}/striver${query}`);
+    if (!response.ok) {
+      throw new Error(`API Error: ${response.status}`);
+    }
+    return await response.json();
   }
 };
 
@@ -157,6 +167,7 @@ const App = () => {
           <div className="space-y-4">
             <HintPanel hints={hints} isLoading={isLoading} />
             <SubmissionHistory submissions={analysisHistory} />
+            <StriverSheet api={apiService} />
           </div>
           
         </div>

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders CI-MAN-YD header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/CI-MAN-YD/i);
+  expect(headerElement).toBeInTheDocument();
 });

--- a/client/src/StriverSheet.js
+++ b/client/src/StriverSheet.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { List, CheckSquare, Square } from 'lucide-react';
+
+const StriverSheet = ({ api }) => {
+  const [questions, setQuestions] = useState([]);
+  const [completed, setCompleted] = useState([]);
+
+  const loadQuestions = useCallback(async () => {
+    try {
+      const data = await api.getStriverQuestions(true);
+      setQuestions(data);
+    } catch (err) {
+      console.error('Failed to load questions', err);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    const done = JSON.parse(localStorage.getItem('striverDone') || '[]');
+    setCompleted(done);
+    loadQuestions();
+  }, [loadQuestions]);
+
+  const toggleDone = (id) => {
+    let updated;
+    if (completed.includes(id)) {
+      updated = completed.filter((d) => d !== id);
+    } else {
+      updated = [...completed, id];
+    }
+    setCompleted(updated);
+    localStorage.setItem('striverDone', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+        <List className="h-5 w-5 mr-2" />
+        Striver Sheet
+      </h2>
+      <p className="text-sm text-gray-600 mb-2">
+        {completed.length}/{questions.length} completed
+      </p>
+      <ul className="space-y-2">
+        {questions.map((q) => (
+          <li key={q.id} className="flex items-center justify-between">
+            <a
+              href={q.link}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm text-blue-600 hover:underline"
+            >
+              {q.title}
+            </a>
+            <button onClick={() => toggleDone(q.id)} className="ml-2">
+              {completed.includes(q.id) ? (
+                <CheckSquare className="h-4 w-4 text-green-600" />
+              ) : (
+                <Square className="h-4 w-4 text-gray-400" />
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StriverSheet;

--- a/server/routes/striver.js
+++ b/server/routes/striver.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const questions = require('../services/striverData');
+
+router.get('/', (req, res) => {
+  const { shuffle } = req.query;
+  let data = [...questions];
+  if (shuffle === 'true') {
+    data.sort(() => Math.random() - 0.5);
+  }
+  res.json(data);
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ app.use(express.json());
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/code', require('./routes/code'));
 app.use('/api/users', require('./routes/users'));
+app.use('/api/striver', require('./routes/striver'));
 
 // Test route
 app.get('/', (req, res) => {

--- a/server/services/striverData.js
+++ b/server/services/striverData.js
@@ -1,0 +1,12 @@
+module.exports = [
+  { id: 1, title: 'Set Matrix Zeroes', link: 'https://takeuforward.org/data-structure/set-matrix-zeroes/' },
+  { id: 2, title: 'Pascal Triangle', link: 'https://takeuforward.org/data-structure/pascal-triangle/' },
+  { id: 3, title: 'Next Permutation', link: 'https://takeuforward.org/data-structure/next-permutation-find-next-lexicographically-greater-permutation/' },
+  { id: 4, title: 'Kadane\'s Algorithm', link: 'https://takeuforward.org/data-structure/kadanes-algorithm-maximum-subarray-sum-in-an-array/' },
+  { id: 5, title: 'Sort Colors', link: 'https://takeuforward.org/data-structure/sort-an-array-of-0s-1s-and-2s/' },
+  { id: 6, title: 'Merge Intervals', link: 'https://takeuforward.org/data-structure/merge-overlapping-sub-intervals/' },
+  { id: 7, title: 'Best Time to Buy and Sell Stock', link: 'https://takeuforward.org/data-structure/stock-buy-and-sell/' },
+  { id: 8, title: 'Two Sum', link: 'https://takeuforward.org/data-structure/find-the-two-number-sum-in-an-array/' },
+  { id: 9, title: 'Longest Substring Without Repeating Characters', link: 'https://takeuforward.org/data-structure/length-of-longest-substring-without-any-repeating-character/' },
+  { id: 10, title: 'Reverse Linked List', link: 'https://takeuforward.org/data-structure/reverse-a-linked-list/' }
+];


### PR DESCRIPTION
## Summary
- add bullet to README about tracking Striver sheet questions
- expose `/api/striver` endpoint on server
- store a sample list of Striver SDE sheet questions
- extend API helper with `getStriverQuestions`
- show `StriverSheet` component in UI
- refactor StriverSheet logic to use `useCallback`
- update React test to look for the app header

## Testing
- `npm test --silent --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_686f69e80490832aaad580bb0c7a4dc2